### PR TITLE
Fix minor issues wrt git ahead/behind status, dir hist, and bookmarks

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -700,7 +700,7 @@ set -g cmd_hist cmd_hist_nosession
 set -g CMD_DURATION 0
 set -g dir_hist_nosession
 set -g dir_hist dir_hist_nosession
-set -g pwd_hist_lock false
+set -g pwd_hist_lock true
 set -g pcount 1
 set -g prompt_hist
 set -g no_prompt_hist 'F'

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -738,7 +738,9 @@ if not begin
     or set -q -x RANGER_LEVEL
     or set -q -x VIM
   end ^ /dev/null
-  cd $bookmarks[1]
+  if set -q bookmarks[1]
+    cd $bookmarks[1]
+  end
 end
 set -x LOGIN $USER
 

--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -79,7 +79,11 @@ end
 # => Git segment
 ################
 function __budspencer_is_git_ahead_or_behind -d 'Check if there are unpulled or unpushed commits'
-  command git rev-list --count --left-right 'HEAD...@{upstream}' ^ /dev/null  | sed 's|\s\+|\n|g'
+  if set -l ahead_or_behind (command git rev-list --count --left-right 'HEAD...@{upstream}' ^ /dev/null)
+    echo $ahead_or_behind | sed 's|\s\+|\n|g'
+  else
+    echo 0\n0
+  end
 end
 
 function __budspencer_git_status -d 'Check git status'

--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -111,7 +111,7 @@ function __budspencer_prompt_git_symbols -d 'Displays the git symbols'
   set -l git_status (__budspencer_git_status)
   set -l git_stashed (__budspencer_is_git_stashed)
 
-  if [ (expr $git_status[1] + $git_status[2] + $git_status[3] + $git_status[4] + $git_status[5] + $git_status[6] + $git_stashed) -ne 0 ]
+  if [ (expr $git_ahead_behind[1] + $git_ahead_behind[2] + $git_status[1] + $git_status[2] + $git_status[3] + $git_status[4] + $git_status[5] + $git_status[6] + $git_stashed) -ne 0 ]
     set_color $budspencer_colors[3]
     echo -n ''
     set_color -b $budspencer_colors[3]


### PR DESCRIPTION
This PR ensures the following:
* ahead and behind status for git does not fail for non-tracking branches
* display of ahead and behind status, when all other status are not applicable (clean repo)
* new shells spawn correctly when no bookmarks are set
* the theme's dir history is populated with the first PWD