### PR TITLE
Remove superfluous check from prompt_git_symbols

### DIFF
--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -124,15 +124,13 @@ function __budspencer_prompt_git_symbols -d 'Displays the git symbols'
     switch $pwd_style
       case long short
         if [ $symbols_style = 'symbols' ]
-          if [ (count $git_ahead_behind) -eq 2 ]
-            if [ $git_ahead_behind[1] -gt 0 ]
-              set_color -o $budspencer_colors[5]
-              echo -n ' ↑'
-            end
-            if [ $git_ahead_behind[2] -gt 0 ]
-              set_color -o $budspencer_colors[5]
-              echo -n ' ↓'
-            end
+          if [ $git_ahead_behind[1] -gt 0 ]
+            set_color -o $budspencer_colors[5]
+            echo -n ' ↑'
+          end
+          if [ $git_ahead_behind[2] -gt 0 ]
+            set_color -o $budspencer_colors[5]
+            echo -n ' ↓'
           end
           if [ $git_status[1] -gt 0 ]
             set_color -o $budspencer_colors[12]
@@ -163,15 +161,13 @@ function __budspencer_prompt_git_symbols -d 'Displays the git symbols'
             echo -n ' ✭'
           end
         else
-          if [ (count $git_ahead_behind) -eq 2 ]
-            if [ $git_ahead_behind[1] -gt 0 ]
-              set_color $budspencer_colors[5]
-              echo -n ' '$git_ahead_behind[1]
-            end
-            if [ $git_ahead_behind[2] -gt 0 ]
-              set_color $budspencer_colors[5]
-              echo -n ' '$git_ahead_behind[2]
-            end
+          if [ $git_ahead_behind[1] -gt 0 ]
+            set_color $budspencer_colors[5]
+            echo -n ' '$git_ahead_behind[1]
+          end
+          if [ $git_ahead_behind[2] -gt 0 ]
+            set_color $budspencer_colors[5]
+            echo -n ' '$git_ahead_behind[2]
           end
           if [ $git_status[1] -gt 0 ]
             set_color $budspencer_colors[12]

--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -128,79 +128,79 @@ function __budspencer_prompt_git_symbols -d 'Displays the git symbols'
             if [ $git_ahead_behind[1] -gt 0 ]
               set_color -o $budspencer_colors[5]
               echo -n ' ↑'
-                  end
-                  if [ $git_ahead_behind[2] -gt 0 ]
-                    set_color -o $budspencer_colors[5]
-                    echo -n ' ↓'
-                  end
-              end
-              if [ $git_status[1] -gt 0 ]
-                set_color -o $budspencer_colors[12]
-                echo -n ' +'
-              end
-              if [ $git_status[2] -gt 0 ]
-                set_color -o $budspencer_colors[7]
-                echo -n ' –'
-              end
-              if [ $git_status[3] -gt 0 ]
-                set_color -o $budspencer_colors[10]
-                echo -n ' ✱'
-              end
-              if [ $git_status[4] -gt 0 ]
-                set_color -o $budspencer_colors[8]
-                echo -n ' →'
-              end
-              if [ $git_status[5] -gt 0 ]
-                set_color -o $budspencer_colors[9]
-                echo -n ' ═'
-              end
-              if [ $git_status[6] -gt 0 ]
-                set_color -o $budspencer_colors[4]
-                echo -n ' ●'
-              end
-              if [ $git_stashed -gt 0 ]
-                set_color -o $budspencer_colors[11]
-                echo -n ' ✭'
-              end
-          else
-            if [ (count $git_ahead_behind) -eq 2 ]
-              if [ $git_ahead_behind[1] -gt 0 ]
-                set_color $budspencer_colors[5]
-                echo -n ' '$git_ahead_behind[1]
-                  end
-                  if [ $git_ahead_behind[2] -gt 0 ]
-                    set_color $budspencer_colors[5]
-                    echo -n ' '$git_ahead_behind[2]
-                  end
-              end
-              if [ $git_status[1] -gt 0 ]
-                set_color $budspencer_colors[12]
-                echo -n ' '$git_status[1]
-              end
-              if [ $git_status[2] -gt 0 ]
-                set_color $budspencer_colors[7]
-                echo -n ' '$git_status[2]
-              end
-              if [ $git_status[3] -gt 0 ]
-                set_color $budspencer_colors[10]
-                echo -n ' '$git_status[3]
-              end
-              if [ $git_status[4] -gt 0 ]
-                set_color $budspencer_colors[8]
-                echo -n ' '$git_status[4]
-              end
-              if [ $git_status[5] -gt 0 ]
-                set_color $budspencer_colors[9]
-                echo -n ' '$git_status[5]
-              end
-              if [ $git_status[6] -gt 0 ]
-                set_color $budspencer_colors[4]
-                echo -n ' '$git_status[6]
-              end
-              if [ $git_stashed -gt 0 ]
-                set_color $budspencer_colors[11]
-                echo -n ' '$git_stashed
-              end
+            end
+            if [ $git_ahead_behind[2] -gt 0 ]
+              set_color -o $budspencer_colors[5]
+              echo -n ' ↓'
+            end
+          end
+          if [ $git_status[1] -gt 0 ]
+            set_color -o $budspencer_colors[12]
+            echo -n ' +'
+          end
+          if [ $git_status[2] -gt 0 ]
+            set_color -o $budspencer_colors[7]
+            echo -n ' –'
+          end
+          if [ $git_status[3] -gt 0 ]
+            set_color -o $budspencer_colors[10]
+            echo -n ' ✱'
+          end
+          if [ $git_status[4] -gt 0 ]
+            set_color -o $budspencer_colors[8]
+            echo -n ' →'
+          end
+          if [ $git_status[5] -gt 0 ]
+            set_color -o $budspencer_colors[9]
+            echo -n ' ═'
+          end
+          if [ $git_status[6] -gt 0 ]
+            set_color -o $budspencer_colors[4]
+            echo -n ' ●'
+          end
+          if [ $git_stashed -gt 0 ]
+            set_color -o $budspencer_colors[11]
+            echo -n ' ✭'
+          end
+        else
+          if [ (count $git_ahead_behind) -eq 2 ]
+            if [ $git_ahead_behind[1] -gt 0 ]
+              set_color $budspencer_colors[5]
+              echo -n ' '$git_ahead_behind[1]
+            end
+            if [ $git_ahead_behind[2] -gt 0 ]
+              set_color $budspencer_colors[5]
+              echo -n ' '$git_ahead_behind[2]
+            end
+          end
+          if [ $git_status[1] -gt 0 ]
+            set_color $budspencer_colors[12]
+            echo -n ' '$git_status[1]
+          end
+          if [ $git_status[2] -gt 0 ]
+            set_color $budspencer_colors[7]
+            echo -n ' '$git_status[2]
+          end
+          if [ $git_status[3] -gt 0 ]
+            set_color $budspencer_colors[10]
+            echo -n ' '$git_status[3]
+          end
+          if [ $git_status[4] -gt 0 ]
+            set_color $budspencer_colors[8]
+            echo -n ' '$git_status[4]
+          end
+          if [ $git_status[5] -gt 0 ]
+            set_color $budspencer_colors[9]
+            echo -n ' '$git_status[5]
+          end
+          if [ $git_status[6] -gt 0 ]
+            set_color $budspencer_colors[4]
+            echo -n ' '$git_status[6]
+          end
+          if [ $git_stashed -gt 0 ]
+            set_color $budspencer_colors[11]
+            echo -n ' '$git_stashed
+          end
         end
         set_color -b $budspencer_colors[3] normal
         echo -n ' '


### PR DESCRIPTION
As of fd03f7686dbfc45980230b652a890553b596819a, I ensured that `__budspencer_is_git_ahead_or_behind` always returns a list with two items. From then on, checking the methods return value was no longer necessary. Removing the check helps to unify the structure of `__budspencer_prompt_git_symbols`.

Before removal, I correctly indented `__budspencer_prompt_git_symbols`. It was misaligned before.