### PR TITLE
Ensure correct display of shortened prompt

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -568,7 +568,7 @@ function __budspencer_prompt_git_branch -d 'Return the current branch name'
       case short long
         echo -n ''(set_color $budspencer_colors[1])'  '$branch' '(set_color $budspencer_colors[3])
       case none
-    echo -n ''
+        echo -n ''
     end
     set_color normal
     set_color $budspencer_colors[3]

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -602,7 +602,7 @@ function __budspencer_prompt_bindmode -d 'Displays the current mode'
     case short long
       echo -n " $pcount "
   end
-  set_color -b $budspencer_colors[1] $budspencer_current_bindmode_color
+  set_color -b normal $budspencer_current_bindmode_color
 end
 
 ####################

--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -212,14 +212,14 @@ function __budspencer_prompt_pwd -d 'Displays the present working directory'
   if set -q SSH_CLIENT
     if [ $symbols_style = 'symbols' ]
       switch $pwd_style
-          case short
-            set user_host " $USER@"(hostname -s)':'
-          case long
-            set user_host " $USER@"(hostname -f)':'
-          end
-      else
-        set user_host " $USER@"(hostname -i)':'
+        case short
+          set user_host " $USER@"(hostname -s)':'
+        case long
+          set user_host " $USER@"(hostname -f)':'
       end
+    else
+      set user_host " $USER@"(hostname -i)':'
+    end
   end
   set_color $budspencer_current_bindmode_color
   echo -n ''
@@ -231,7 +231,7 @@ function __budspencer_prompt_pwd -d 'Displays the present working directory'
         echo -n $user_host(prompt_pwd)' '
       case long
         echo -n $user_host(pwd)' '
-      end
+    end
   else
     echo -n " $budspencer_prompt_error "
     set -e budspencer_prompt_error[1]


### PR DESCRIPTION
In case, no left symbols are displayed and no git repo is available, a solid black bar ($budspencer_colors[1]) covered the back instead of the regular terminal background.

![none-prompt](https://cloud.githubusercontent.com/assets/1137575/11104794/29103380-88cb-11e5-8460-1e26eba465d4.png)

In the process of debugging this, I unified the indentation levels for misaligned code I came across.