### PR TITLE
Fixes

### DIFF
--- a/fish_mode_prompt.fish
+++ b/fish_mode_prompt.fish
@@ -1,0 +1,3 @@
+function fish_mode_prompt
+  # Turns off mode indicator
+end

--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -10,6 +10,7 @@
 #   Joseph Tannhuber <sepp.tannhuber@yahoo.de>
 #
 # Sections:
+#   -> TTY Detection
 #   -> Functions
 #     -> Toggle functions
 #     -> Command duration segment
@@ -18,6 +19,15 @@
 #   -> Prompt
 #
 ###############################################################################
+
+###############################################################################
+# => TTY Detection
+###############################################################################
+
+# Automatically disables right prompt when in a tty
+if tty | grep tty >/dev/null
+  exit
+end
 
 ###############################################################################
 # => Functions


### PR DESCRIPTION
Fixes the annoying warnings by disabling the right_prompt when in a tty. Also removes the vi mode indicator which was recently made default upstream.

Fixes issue #21 