### PR TITLE
Remove tty check in Darwin

### DIFF
--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -25,8 +25,11 @@
 ###############################################################################
 
 # Automatically disables right prompt when in a tty
-if tty | grep tty >/dev/null
-  exit
+# Except in Darwin due to OS X terminals identifying themselves as a tty
+if not test (uname) = Darwin
+  if tty | grep tty >/dev/null
+    exit
+  end
 end
 
 ###############################################################################


### PR DESCRIPTION
Fixes issue #30. I've never used a Mac but it seems iTerm, Terminal.app and possibly others identify themselves a tty. This merge disables tty detection entirely for Darwin.