### PR TITLE
Fixed 'Variables may not be used as commands' promt when starting shell

### DIFF
--- a/fish_greeting.fish
+++ b/fish_greeting.fish
@@ -24,7 +24,7 @@ function fish_greeting -d 'Show greeting in login shell.'
       and not set -q -x RANGER_LEVEL
       and not set -q -x VIM
       end
-      echo This is (set_color -b $budspencer_colors[2]
+      echo This is (set_color -b $budspencer_colors[2] \
       $budspencer_colors[10])budspencer(set_color normal) theme for fish, a theme for nerds.
       echo Type (set_color -b $budspencer_colors[2] $budspencer_colors[6])»budspencer_help«(set_color normal) in order to see how you can speed up your workflow.
       end


### PR DESCRIPTION
When shell is opened a message:

`Variables may not be used as commands. In fish, please define a function or use 'eval $budspencer_colors[10]'.
~/.local/share/omf/themes/budspencer/fish_greeting.fish (line 2):       $budspencer_colors[10]
                                                                        ^
in command substitution
        called on line 19 of file ~/.local/share/omf/themes/budspencer/fish_greeting.fish

in function 'fish_greeting'
        called on line 123 of file /usr/local/share/fish/functions/__fish_config_interactive.fish

in function '__fish_config_interactive'
        called on line 180 of file /usr/local/share/fish/config.fish

in function '__fish_on_interactive'
        called on standard input

in event handler: handler for generic event 'fish_prompt'

`
appears for fish 2.1.0+ (didn't test for earlier)