### PR TITLE
Locates grep path

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -845,8 +845,11 @@ set -g prompt_hist
 set -g no_prompt_hist 'F'
 set -g symbols_style 'symbols'
 
+#Locates grep path in user's system
+set -g grep_path eval (which grep)
+
 # Fix for WSL showing wrong command number at start
-if test (uname -r | /bin/grep [Mm]icrosoft)
+if test (uname -r | $grep_path [Mm]icrosoft)
   set -g pcount 0
 end
 


### PR DESCRIPTION
Hello, on my macOS 11.2.3 grep is in /usr/bin/grep 

This produces the error bellow: 

`fish: Unknown command: /bin/grep
~/.config/fish/functions/fish_prompt.fish (line 1): 
uname -r | /bin/grep [Mm]icrosoft
           ^`